### PR TITLE
Make doc a little less gender-naïve

### DIFF
--- a/_posts/2012-07-08-making-translations-depend-on-external-variables.md
+++ b/_posts/2012-07-08-making-translations-depend-on-external-variables.md
@@ -6,8 +6,8 @@ layout: learn
 <section class="clearfix">
 	<div class="left">
 		<p>Context data can be very useful in defining simple logic for L20n to obey.  You can write your L20n code such that it adapts to different values of context data variables.  For instance, you can instruct L20n to choose a variant of the translation based on the user's gender.</p>
-		<p>The user's gender is unknown at the time of writing the L20n code.  The developer is responsible for assigning a value to it at runtime.  As a localizer, you can prepare your L20n code in a way that accommodates two common values of the user's gender variable.</p>
-		<p>Dictionary indexes (see <a href="{% post_url 2012-07-05-choosing-one-variant %}">Chapter 5. Choosing one variant</a>) are the perfect tool for achieving this.  You can define multiple variants of the translation, one for each supported value, and then use an index defined on the entity to select the proper message.</p>
+		<p>The user's gender is unknown at the time of writing the L20n code.  The developer is responsible for assigning a value to it at runtime.  As a localizer, you can prepare your L20n code in a way that accommodates all (or most) of the possible values of the user's gender variable.</p>
+		<p>Dictionary indexes (see <a href="{% post_url 2012-07-05-choosing-one-variant %}">Chapter 5. Choosing one variant</a>) are the perfect tool for achieving this.  You can define multiple variants of the translation, one for each supported value, and then use an index defined on the entity to select the proper message.  The example below has two different values for two possible genders in English:</p>
 	</div>
 	<div class="right">
 		<div class="editor dataEditor height15"


### PR DESCRIPTION
I noticed a small grammar inconsistency in the doc (missing possessive in the unknown variant, which created a small difference in meaning (“shared with her nnn followers” vs. “shared with nnn followers”)), so I fixed it by using the handy gender-neutral possessive, and then edited another part of the file to remove the assumption that there are only two genders.
