### PR TITLE
jQuery can not be loaded async

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -20,7 +20,7 @@
         <link rel="stylesheet" href="/css/normalize.min.css">
         <link rel="stylesheet" href="/css/main.css">
 
-        <script async src="/js/jquery-2.2.3.js"></script>
+        <script src="/js/jquery-2.2.3.js"></script>
 
         <!--[if lt IE 9]>
             <script src="/js/html5-3.6-respond-1.1.0.min.js"></script>


### PR DESCRIPTION
Other scripts on the page depend on `$` being available when they are loaded, so jQuery must be loaded first (or all of the other scripts need to be refactored to deal with async, but this is simpler).
