### PR TITLE
fix builtin learn example

### DIFF
--- a/_posts/2016-04-04-builtins.md
+++ b/_posts/2016-04-04-builtins.md
@@ -40,7 +40,7 @@ title: "Builtins"
 		>emails = You have { $unreadEmails } unread emails.
 emails2 = You have { NUMBER($unreadEmails) } unread emails.
 
-last-notice = Last checked: { DATETIME($lastChecked, day: "numeric", month: "long") }.
+last-notice = Last checked: { DATETIME($lastChecked, day = "numeric", month = "long") }.
 		</div>
 		<dl id="output1">
 		</dl>


### PR DESCRIPTION
Based on the L20n (FTL) Specifications, the (04 builtin) example corrected in this PR was wrong.

In the example we can see a keyword-argument, using `:` as the operator, while `=` is the specified operator in the EBFN L20n FTL Grammar.

Reference: https://github.com/l20n/spec/blob/master/grammar.ebnf#L49